### PR TITLE
[Cycode] Fix for vulnerable manifest file dependency - github.com/go-git/go-git/v5 updated to version 5.11.0

### DIFF
--- a/scenarios/cicd/terraform/test/go.mod
+++ b/scenarios/cicd/terraform/test/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/aws/smithy-go v1.9.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-git/go-git/v5 v5.4.2
+	github.com/go-git/go-git/v5 v5.11.0
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.3 // indirect


### PR DESCRIPTION
[Cycode] Fix for vulnerable manifest file dependency - github.com/go-git/go-git/v5 updated to version 5.11.0